### PR TITLE
CI: split lint/typecheck/test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   POETRY_NO_INTERACTION: "1"
   POETRY_VIRTUALENVS_CREATE: true
+  PYTHONPATH: "src"
 
 jobs:
   lint:


### PR DESCRIPTION
## What changed?
- 

## Why?
- 

## How to test
- [ ] `PYTHONPATH=. poetry run python -m pytest`
- [ ] `PYTHONPATH=. poetry run python scripts/run_sim.py`

## Screenshots / logs (if relevant)
-

## Linked issues
Closes #