### PR TITLE
Engine: add clock abstraction for simulation

### DIFF
--- a/src/vivariumassistant/packages/core/clock.py
+++ b/src/vivariumassistant/packages/core/clock.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+
+class Clock(ABC):
+    @abstractmethod
+    def now(self) -> datetime:
+        """Return the current timezone-aware datetime."""
+
+
+class RealClock(Clock):
+    def __init__(self, timezone: str):
+        self._tz = ZoneInfo(timezone)
+
+    def now(self) -> datetime:
+        return datetime.now(tz=self._tz)
+
+
+class SimClock(Clock):
+    def __init__(self, start: datetime):
+        if start.tzinfo is None:
+            raise ValueError("SimClock start datetime must be timezone-aware")
+        self._now = start
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, seconds: int) -> None:
+        self._now = self._now + timedelta(seconds=seconds)

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from vivariumassistant.packages.core.clock import SimClock
+
+
+def test_sim_clock_requires_timezone():
+    with pytest.raises(ValueError):
+        SimClock(datetime(2025, 1, 1))  # naive datetime
+
+
+def test_sim_clock_advances():
+    start = datetime(2025, 1, 1, tzinfo=ZoneInfo("UTC"))
+    clock = SimClock(start)
+
+    assert clock.now() == start
+    clock.advance(60)
+    assert clock.now() == start + timedelta(seconds=60)


### PR DESCRIPTION
Adds a Clock abstraction with RealClock and SimClock + tests.

No behavior changes yet; enables simulation and deterministic engine testing.

## How to test
- [ ] `PYTHONPATH=. poetry run python -m pytest`
- [ ] `PYTHONPATH=. poetry run python scripts/run_sim.py`

## Screenshots / logs (if relevant)
-

## Linked issues
Closes #