### PR TITLE
docs: establish repository documentation baseline

### DIFF
--- a/docs/decisions/000-template.md
+++ b/docs/decisions/000-template.md
@@ -1,0 +1,47 @@
+# Decision: <short, descriptive title>
+
+- **Status:** Proposed | Accepted | Superseded
+- **Date:** YYYY-MM-DD
+- **Owners:** @<github-handle>
+
+## Context
+What problem are we solving?
+What constraints, goals, or prior decisions shape this choice?
+
+This section should explain *why this decision exists at all*.
+
+## Options considered
+
+### Option A: <name>
+- **Pros**
+  - 
+- **Cons**
+  - 
+
+### Option B: <name>
+- **Pros**
+  - 
+- **Cons**
+  - 
+
+### Option C (if needed): <name>
+- **Pros**
+  - 
+- **Cons**
+  - 
+
+## Decision
+Clearly state what we are doing and *why this option was chosen*.
+This should be concise but decisive.
+
+## Consequences
+What this decision:
+- enables
+- makes harder
+- defers or rules out
+
+Include follow-up work that this decision implies.
+
+## Links
+- **Related issues:** #
+- **Related docs:** 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,65 @@
+# Architecture Decisions
+
+This directory contains **Architecture Decision Records (ADRs)** for VivariumAssistant.
+
+An ADR documents a **significant technical or architectural choice** that affects the structure, behavior, or future direction of the system.
+
+Decisions are written once, reviewed, and then treated as **historical record** — not rewritten later to match new opinions.
+
+---
+
+## Why decisions exist
+
+VivariumAssistant is intentionally:
+- deterministic
+- hardware-agnostic
+- simulation-first
+- safety-oriented
+
+These constraints require **explicit tradeoffs**.
+
+Decisions help us:
+- avoid re-litigating past discussions
+- onboard new contributors faster
+- keep architecture consistent over time
+- understand *why* something was built a certain way
+
+---
+
+## What should be a decision?
+
+Create a decision when:
+- multiple reasonable options exist
+- the choice impacts more than one module
+- the decision affects future extensibility
+- reversing the decision later would be costly
+
+Examples:
+- Agent vs runtime responsibilities
+- Hardware driver abstraction design
+- Logging architecture
+- Override precedence rules
+- Simulation vs real-hardware parity guarantees
+
+Non-examples:
+- naming variables
+- formatting choices
+- small refactors
+
+---
+
+## Decision lifecycle
+
+Each decision has a **status**:
+
+- **Proposed** — under discussion, not yet accepted
+- **Accepted** — agreed upon and implemented
+- **Superseded** — replaced by a newer decision (link required)
+
+Decisions are **never deleted**.
+
+---
+
+## File naming convention
+
+Decisions use a numeric prefix to preserve ordering:


### PR DESCRIPTION
## What changed?
- Established a structured documentation system under `/docs`
- Added high-level architecture, configuration, logging, and glossary docs
- Organized existing technical docs into `/docs/guides`
- Introduced decision record structure (`docs/decisions`)
- Added `CHANGELOG.md` and `CONTRIBUTING.md`
- Updated PR template to standardize review expectations

## Why?
- Make the repository understandable to new contributors of any skill level
- Reduce onboarding friction and future knowledge loss
- Clearly document architectural boundaries and design intent
- Support milestone-based development with decision records
- Treat VivariumAssistant as a long-lived, professional codebase

## How to test
- [x] Documentation only — no runtime behavior changes
- [x] Repository structure reviewed manually
- [x] Local quality checks remain green:
  - `poetry run ruff check .`
  - `poetry run mypy .`
  - `poetry run pytest -q`
- [x] Simulator still runs as expected:
  - `poetry run python scripts/run_sim.py`

## Screenshots / logs (if relevant)
- N/A (documentation and structure changes only)

## Linked issues
- Closes documentation baseline issue
- Supports completion of Milestone 1 and readiness for Milestone 2