### PR TITLE
Hardware: add gpiozero relay driver + real-mode pin mapping

### DIFF
--- a/config/enclosures/enclosure_1.yaml
+++ b/config/enclosures/enclosure_1.yaml
@@ -24,6 +24,7 @@ devices:
     driver: i2c_relay
     params:
       channel: 1
+      gpio_pin: 16
 
   - id: mister
     name: "Mister"
@@ -32,6 +33,7 @@ devices:
     driver: i2c_relay
     params:
       channel: 2
+      gpio_pin: 18
 
   - id: waterfall
     name: "Waterfall Pump"
@@ -40,6 +42,7 @@ devices:
     driver: i2c_relay
     params:
       channel: 3
+      gpio_pin: 22
 
 sensors:
   - id: climate_1

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,44 @@ files = [
 ]
 
 [[package]]
+name = "colorzero"
+version = "2.0"
+description = "Yet another Python color library"
+optional = false
+python-versions = "*"
+groups = ["hardware"]
+files = [
+    {file = "colorzero-2.0-py2.py3-none-any.whl", hash = "sha256:0e60d743a6b8071498a56465f7719c96a5e92928f858bab1be2a0d606c9aa0f8"},
+    {file = "colorzero-2.0.tar.gz", hash = "sha256:e7d5a5c26cd0dc37b164ebefc609f388de24f8593b659191e12d85f8f9d5eb58"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[package.extras]
+doc = ["pkginfo", "sphinx", "sphinx-rtd-theme"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "gpiozero"
+version = "2.0.1"
+description = "A simple interface to GPIO devices with Raspberry Pi"
+optional = false
+python-versions = ">=3.9"
+groups = ["hardware"]
+files = [
+    {file = "gpiozero-2.0.1-py3-none-any.whl", hash = "sha256:8f621de357171d574c0b7ea0e358cb66e560818a47b0eeedf41ce1cdbd20c70b"},
+    {file = "gpiozero-2.0.1.tar.gz", hash = "sha256:d4ea1952689ec7e331f9d4ebc9adb15f1d01c2c9dcfabb72e752c9869ab7e97e"},
+]
+
+[package.dependencies]
+colorzero = "*"
+
+[package.extras]
+doc = ["sphinx (>=4.0)", "sphinx-rtd-theme (>=1.0)"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
@@ -608,6 +646,27 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+groups = ["hardware"]
+files = [
+    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
+    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 description = "Typing stubs for PyYAML"
@@ -649,4 +708,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "329418169df902f5962da86d1e9473ba15a16349e2b5322b2bd0df0425e93565"
+content-hash = "ad163b9beadd87264c4a4c550d4edd7e07a13b820d91fde5abad207528eb0c39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,9 @@ testpaths = ["tests"]
 [tool.poetry]
 package-mode = true
 packages = [{ include = "vivariumassistant", from = "src" }]
+
+[tool.poetry.group.hardware]
+optional = true
+
+[tool.poetry.group.hardware.dependencies]
+gpiozero = "^2.0"

--- a/scripts/smoke_relay.py
+++ b/scripts/smoke_relay.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from vivariumassistant.packages.core.config_loader import load_enclosure
+from vivariumassistant.packages.drivers.factory import build_drivers
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enclosure", default="enclosure_1")
+    ap.add_argument("--channel", type=int, required=True)
+    ap.add_argument("--on", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    enc = load_enclosure(args.enclosure)
+    bundle = build_drivers(enc)
+
+    if args.dry_run:
+        print(f"[dry-run] mode={bundle.mode} set channel={args.channel} on={args.on}")
+        return
+
+    await bundle.relay.set_on(args.channel, args.on)
+    print(f"Set relay channel {args.channel} -> {args.on}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/vivariumassistant/packages/drivers/real_relay_gpiozero.py
+++ b/src/vivariumassistant/packages/drivers/real_relay_gpiozero.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Protocol, cast
+
+from vivariumassistant.packages.drivers.base import RelayDriver
+
+try:
+    from gpiozero import DigitalOutputDevice  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover
+    DigitalOutputDevice = None  # type: ignore[assignment]
+
+
+class _RelayDevice(Protocol):
+    """Minimum interface we need from a relay output device."""
+
+    def on(self) -> None: ...
+    def off(self) -> None: ...
+    def close(self) -> None: ...
+
+
+class RealRelayDriverGpioZero(RelayDriver):
+    """
+    Real relay driver using gpiozero. Channels map to BCM GPIO pins.
+
+    Safety:
+    - Outputs default OFF on creation (initial_value=False).
+    - This driver should only be constructed behind the REAL-mode safety gate.
+    """
+
+    def __init__(self) -> None:
+        # DigitalOutputDevice is either a constructor or None depending on environment.
+        if DigitalOutputDevice is None:
+            raise RuntimeError(
+                "gpiozero is not available. Install it on the Raspberry Pi environment "
+                "(e.g., `poetry add gpiozero`) and run with REAL mode enabled."
+            )
+
+        self._channels: dict[int, _RelayDevice] = {}
+        self._state: dict[int, bool] = {}
+
+    def register_channel(self, channel: int, bcm_pin: int) -> None:
+        """
+        Register a relay output channel mapped to a BCM GPIO pin.
+        """
+        # gpiozero creates the device and we force a safe default OFF
+        dev = DigitalOutputDevice(bcm_pin, initial_value=False)  # type: ignore[misc]
+        self._channels[channel] = cast(_RelayDevice, dev)
+        self._state[channel] = False
+
+    async def set_on(self, channel: int, on: bool) -> None:
+        dev = self._channels[channel]
+        if on:
+            dev.on()
+        else:
+            dev.off()
+        self._state[channel] = on
+
+    async def get_on(self, channel: int) -> bool:
+        return self._state.get(channel, False)
+
+    def close(self) -> None:
+        """
+        Best-effort safe shutdown.
+        """
+        for _, dev in self._channels.items():
+            try:
+                dev.off()
+            except Exception:
+                pass
+            try:
+                dev.close()
+            except Exception:
+                pass
+        self._channels.clear()
+        self._state.clear()


### PR DESCRIPTION
## What changed?
- Added a REAL relay driver using gpiozero (safe default OFF).
- Added REAL-mode pin mapping support via `params.gpio_pin` in enclosure device config.
- Kept PWM in SIM for now (REAL PWM is a follow-up issue).

## Why?
- Establishes the first hardware-capable driver while keeping strict safety gates to prevent accidental GPIO toggling in dev environments.

## How to test
- [ ] `poetry run ruff check .`
- [ ] `poetry run mypy .`
- [ ] `poetry run pytest -q`
- [ ] (SIM) `poetry run python scripts/run_sim.py`
- [ ] (REAL, Pi only) `VA_ENABLE_REAL=1` + `runtime.mode=real` and verify relay driver initializes and can toggle a configured pin.

## Screenshots / logs (if relevant)
- N/A

## Linked issues
Closes #31